### PR TITLE
chore: GitHub Pages へのデプロイを実装

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # main ブランチに push されたときに実行される
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build React app
+        run: pnpm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          enable_jekyll: false

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,8 @@ import { defineConfig } from "vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: "/oraclane/",
+  build: {
+    outDir: "dist",
+  },
 });


### PR DESCRIPTION
GitHub Pages へデプロイするため、アクションの作成と設定の追加を行う。

中身は Gemini に教えてもらった。

---

これで実行すると、以下のエラーが出て止まった。

> /usr/bin/git push origin gh-pages
> remote: Permission to tris5572/oraclane.git denied to github-actions[bot].
> fatal: unable to access 'https://github.com/tris5572/oraclane.git/': The requested URL returned error: 403
> Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"

Gemini に聞くと原因を教えてくれたので、言われるがままに対応する。

> これは、ワークフローがリポジトリへの書き込み権限を持っていないために発生します。GitHub Actions のデフォルトの GITHUB_TOKEN は、通常はリポジトリの読み取り権限しか持っていません。しかし、peaceiris/actions-gh-pages アクションのようにブランチにプッシュする（書き込む）必要がある場合、追加の権限が必要です。
> 
> 対処方法
> 
> GitHub Actions ワークフローがリポジトリに書き込めるように、リポジトリの権限設定を変更する必要があります。

1. GitHub リポジトリにアクセスします。 (tris5572/oraclane リポジトリ)
2. Settings タブをクリックします。
3. 左側のサイドバーで Actions をクリックし、さらに General をクリックします。
4. スクロールダウンして Workflow permissions セクションを探します。
5. Read and write permissions を選択します。
6. 最後に、忘れずに Save ボタンをクリックします。

これで Actions のエラーで止まっているアクションを Re-run all jobs で再実行。

正しく `gh-pages` ブランチが作成されたので、GitHub Pages の設定を実施。（それまでは `gh-pages` ブランチが存在しないので、設定できなかった）

1. GitHub リポジトリにアクセスします。
2. Settings タブをクリックします。
3. 左側のサイドバーで Pages をクリックします。
4. Branch のドロップダウンメニューで `gh-pages` を選択し、/ (root) が選択されていることを確認して保存します。

少し待つと、正しく表示された 🚀

https://tris5572.github.io/oraclane/
