### PR TITLE
feat: 情報ビューに合流の画像を表示

### DIFF
--- a/src/components/InformationView.tsx
+++ b/src/components/InformationView.tsx
@@ -1,6 +1,8 @@
 import { useAtomValue } from "jotai";
+import type { CSSProperties } from "react";
 import { selectedPointDataAtom } from "../atoms/app";
-import type { PointDataType } from "../types/types";
+import type { MergePoint, PointDataType } from "../types/types";
+import { MergePin } from "./MergePin";
 
 /**
  * 選択されている地点の情報を表示するコンポーネント
@@ -19,9 +21,32 @@ function DataInner({ data }: { data: PointDataType }) {
   return (
     <>
       <h2>{data.label}</h2>
+      {data.type === "merge" ? <MergeImage data={data} /> : null}
       {data.comments?.map((line) => (
         <p key={line}>{line}</p>
       ))}
     </>
   );
+}
+
+/**
+ * 合流画像を返す
+ *
+ * 角度を `0` にして上向きにして前景だけを描画した SVG を取得し、独自の背景の上に重ねたもの。
+ */
+function MergeImage({ data }: { data: MergePoint }) {
+  const icon = <MergePin data={{ ...data, angle: 0 }} onlyFront />;
+
+  const MERGE_WRAPPER_STYLE: CSSProperties = {
+    background: "hsl(58, 100%, 70%)",
+    display: "flex",
+    alignItems: "center",
+    borderRadius: "8px",
+    width: "30px",
+    height: "26px",
+    overflow: "hidden",
+    marginTop: "8px",
+  };
+
+  return <div style={MERGE_WRAPPER_STYLE}>{icon}</div>;
 }

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -26,6 +26,7 @@ export function MapView() {
           latitude={data.latitude}
           anchor="center"
           onClick={() => setSelectedData({ type: "merge", ...data })}
+          style={{ cursor: "pointer" }}
         >
           <MergePin data={data} />
         </ReactMap.Marker>

--- a/src/components/MergePin.tsx
+++ b/src/components/MergePin.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from "react";
 import type { MergePoint } from "../types/types";
 
 type Props = {
@@ -10,10 +9,10 @@ type Props = {
    * 大きさ。省略時は `40`
    */
   size?: number;
-};
-
-const SVG_STYLE: CSSProperties = {
-  cursor: "pointer",
+  /**
+   * 前景だけを描画する（背景を描画しない）フラグ
+   */
+  onlyFront?: boolean;
 };
 
 // TODO: 道路の種類に応じて色を変える
@@ -21,21 +20,25 @@ const SVG_STYLE: CSSProperties = {
 /**
  * 車線減少を表すピン
  */
-export function MergePin({ data, size = 40 }: Props) {
+export function MergePin({ data, size = 40, onlyFront }: Props) {
   return (
-    <svg height={size} viewBox="0 0 100 100" style={SVG_STYLE}>
+    <svg height={size} viewBox="0 0 100 100">
       <title>{data.label}</title>
       <g transform={`rotate(${data.angle}, 50, 50)`}>
         {/* 背景 */}
-        <path
-          d="M50,2 85,25 L85,80 L75,90 L25,90 L15,80 L15,25 z"
-          fill="hsl(58, 100%, 70%)"
-          stroke="hsl(58, 50%, 50%)"
-          strokeWidth="4"
-          strokeLinejoin="round"
-        />
-        {/* 先端表示 */}
-        <path d="M50,2 L55,20 L45,20 z" fill="hsl(300, 100%, 70%)" />
+        {!onlyFront && (
+          <>
+            <path
+              d="M50,2 85,25 L85,80 L75,90 L25,90 L15,80 L15,25 z"
+              fill="hsl(58, 100%, 70%)"
+              stroke="hsl(58, 50%, 50%)"
+              strokeWidth="4"
+              strokeLinejoin="round"
+            />
+            {/* 先端表示 */}
+            <path d="M50,2 L55,20 L45,20 z" fill="hsl(300, 100%, 70%)" />
+          </>
+        )}
         {/* 外側線 */}
         <g fill="none" stroke="hsl(0, 0%, 0%)" strokeWidth="4">
           {data.merge === "right" ? (


### PR DESCRIPTION
文字だけではなく画像を表示する。

<img width="486" alt="image" src="https://github.com/user-attachments/assets/a0ad0a27-90d1-42ac-93c5-27c47194cb7c" />

分岐については別途対応する。
