### PR TITLE
feat: スマートフォンの表示に対応

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,6 +26,8 @@
   border-radius: 8px;
   width: 25%;
   min-width: 20rem;
+  max-height: 80%;
+  overflow-y: scroll;
   background-color: hsl(200, 10%, 95%, 70%);
   backdrop-filter: blur(4px);
   padding: 12px;

--- a/src/App.css
+++ b/src/App.css
@@ -24,7 +24,8 @@
   top: 8px;
   left: 8px;
   border-radius: 8px;
-  width: 20%;
+  width: 25%;
+  min-width: 20rem;
   background-color: hsl(200, 10%, 95%, 70%);
   backdrop-filter: blur(4px);
   padding: 12px;

--- a/src/App.css
+++ b/src/App.css
@@ -38,3 +38,13 @@
     line-height: 150%;
   }
 }
+
+/* スマートフォン向けのスタイル */
+@media screen and (max-width: 480px) {
+  .information-view {
+    width: calc(100% - 8px - 50px);
+    margin-right: 100px;
+    max-height: 30%;
+    overflow-y: scroll;
+  }
+}

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -58,6 +58,7 @@ export function MapView() {
         zoom: 11,
       }}
       mapStyle="https://tile.openstreetmap.jp/styles/osm-bright-ja/style.json"
+      attributionControl={false}
     >
       {decreaseMarkers}
       {branchMarkers}


### PR DESCRIPTION
スマートフォンでも表示できるよう、情報表示ビューのスタイルを設定する。

PC | SP縦 | SP横
:--: | :--: | :--:
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/4ceb9bc2-a954-44b4-bf2e-6a390453ba45" /> | ![](https://github.com/user-attachments/assets/88ef2928-0a5b-4f87-bd26-3f39df41d99b) | ![](https://github.com/user-attachments/assets/de420ceb-14ec-49a1-86fe-8068e7782bac)

横幅が狭いとき（= 縦画面のとき）に、上部いっぱいに情報を表示するとともに、高さを制限してはみ出した場合はスクロールするように設定する。

横画面のときは PC と SP の両方に対応した汎用表示として、幅を少し変更するとともに、サイズの制限を追加する。

また、画面下部のコントリビューター表示が SP では大きすぎて邪魔だったため、ひとまず完全に非表示とする。初期表示で展開しない方法があればそれで良いが、軽く調べた範囲では分からなかった。
