### PR TITLE
refactor: import 方式の整理などのリファクタリング

### DIFF
--- a/src/assets/mergeData.ts
+++ b/src/assets/mergeData.ts
@@ -420,7 +420,7 @@ const 鹿児島 = [] satisfies MergePoint[];
 
 const 沖縄 = [] satisfies MergePoint[];
 
-export const DECREASE_DATA = [
+export const MERGE_DATA = [
   ...北海道,
   ...青森,
   ...岩手,

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -10,7 +10,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { useSetAtom } from "jotai";
 import { useMemo } from "react";
 import { BRANCH_DATA } from "../assets/branchData";
-import { DECREASE_DATA } from "../assets/mergeData";
+import { MERGE_DATA } from "../assets/mergeData";
 import { selectedPointDataAtom } from "../atoms/app";
 import { BranchPin } from "./BranchPin";
 import { MergePin } from "./MergePin";
@@ -18,9 +18,9 @@ import { MergePin } from "./MergePin";
 export function MapView() {
   const setSelectedData = useSetAtom(selectedPointDataAtom);
 
-  const decreaseMarkers = useMemo(
+  const mergeMarkers = useMemo(
     () =>
-      DECREASE_DATA.map((data) => (
+      MERGE_DATA.map((data) => (
         <Marker
           key={`marker-${data.longitude}-${data.latitude}`}
           longitude={data.longitude}
@@ -61,7 +61,7 @@ export function MapView() {
       mapStyle="https://tile.openstreetmap.jp/styles/osm-bright-ja/style.json"
       attributionControl={false}
     >
-      {decreaseMarkers}
+      {mergeMarkers}
       {branchMarkers}
       <ScaleControl />
       <NavigationControl />

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -22,7 +22,7 @@ export function MapView() {
     () =>
       MERGE_DATA.map((data) => (
         <Marker
-          key={`marker-${data.longitude}-${data.latitude}`}
+          key={`merge-${data.label}-${data.longitude}-${data.latitude}-${data.angle}-${data.merge}`}
           longitude={data.longitude}
           latitude={data.latitude}
           anchor="center"
@@ -39,7 +39,7 @@ export function MapView() {
     () =>
       BRANCH_DATA.map((data) => (
         <Marker
-          key={`marker-${data.longitude}-${data.latitude}`}
+          key={`branch-${data.label}-${data.longitude}-${data.latitude}-${data.angle}`}
           longitude={data.longitude}
           latitude={data.latitude}
           anchor="center"

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,8 +1,9 @@
-import * as ReactMap from "react-map-gl/maplibre";
 import {
   FullscreenControl,
   GeolocateControl,
+  Marker,
   NavigationControl,
+  Map as ReactMap,
   ScaleControl,
 } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
@@ -20,7 +21,7 @@ export function MapView() {
   const decreaseMarkers = useMemo(
     () =>
       DECREASE_DATA.map((data) => (
-        <ReactMap.Marker
+        <Marker
           key={`marker-${data.longitude}-${data.latitude}`}
           longitude={data.longitude}
           latitude={data.latitude}
@@ -29,7 +30,7 @@ export function MapView() {
           style={{ cursor: "pointer" }}
         >
           <MergePin data={data} />
-        </ReactMap.Marker>
+        </Marker>
       )),
     [setSelectedData],
   );
@@ -37,7 +38,7 @@ export function MapView() {
   const branchMarkers = useMemo(
     () =>
       BRANCH_DATA.map((data) => (
-        <ReactMap.Marker
+        <Marker
           key={`marker-${data.longitude}-${data.latitude}`}
           longitude={data.longitude}
           latitude={data.latitude}
@@ -45,13 +46,13 @@ export function MapView() {
           onClick={() => setSelectedData({ type: "branch", ...data })}
         >
           <BranchPin data={data} />
-        </ReactMap.Marker>
+        </Marker>
       )),
     [setSelectedData],
   );
 
   return (
-    <ReactMap.Map
+    <ReactMap
       initialViewState={{
         latitude: 35.7010742,
         longitude: 139.6499634,
@@ -66,6 +67,6 @@ export function MapView() {
       <NavigationControl />
       <FullscreenControl />
       <GeolocateControl />
-    </ReactMap.Map>
+    </ReactMap>
   );
 }


### PR DESCRIPTION
以下のリファクタリングを行う。

- `react-map-gl` の `import` 方法を整理
- 車線減少の変数名を merge に統一
- 地点のマーカーに含める情報を追加

`import` 方法は、Biome による `Map` 上書きの警告に対応するため、別名を付与している。

マーカーのキーは、開発中に少し編集して保存したときに別のマーカーとして区別したいために、情報を追加する。
