### PR TITLE
style: 文字色、スクロールバー表示、合流画像回転方法を変更

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,6 +3,7 @@
   padding: 0;
   box-sizing: border-box;
   font-size: 14px;
+  color: hsl(0, 0%, 20%);
 }
 
 /* #root {

--- a/src/App.css
+++ b/src/App.css
@@ -29,6 +29,7 @@
   min-width: 20rem;
   max-height: 80%;
   overflow-y: scroll;
+  scrollbar-width: none;
   background-color: hsl(200, 10%, 95%, 70%);
   backdrop-filter: blur(4px);
   padding: 12px;

--- a/src/components/MergePin.tsx
+++ b/src/components/MergePin.tsx
@@ -22,63 +22,61 @@ type Props = {
  */
 export function MergePin({ data, size = 40, onlyFront }: Props) {
   return (
-    <svg height={size} viewBox="0 0 100 100">
+    <svg height={size} viewBox="0 0 100 100" transform={`rotate(${data.angle})`}>
       <title>{data.label}</title>
-      <g transform={`rotate(${data.angle}, 50, 50)`}>
-        {/* 背景 */}
-        {!onlyFront && (
-          <>
-            <path
-              d="M50,2 85,25 L85,80 L75,90 L25,90 L15,80 L15,25 z"
-              fill="hsl(58, 100%, 70%)"
-              stroke="hsl(58, 50%, 50%)"
-              strokeWidth="4"
-              strokeLinejoin="round"
-            />
-            {/* 先端表示 */}
-            <path d="M50,2 L55,20 L45,20 z" fill="hsl(300, 100%, 70%)" />
-          </>
+      {/* 背景 */}
+      {!onlyFront && (
+        <>
+          <path
+            d="M50,2 85,25 L85,80 L75,90 L25,90 L15,80 L15,25 z"
+            fill="hsl(58, 100%, 70%)"
+            stroke="hsl(58, 50%, 50%)"
+            strokeWidth="4"
+            strokeLinejoin="round"
+          />
+          {/* 先端表示 */}
+          <path d="M50,2 L55,20 L45,20 z" fill="hsl(300, 100%, 70%)" />
+        </>
+      )}
+      {/* 外側線 */}
+      <g fill="none" stroke="hsl(0, 0%, 0%)" strokeWidth="4">
+        {data.merge === "right" ? (
+          <path d="M35,75 L35,55 L48,45 L48,25" />
+        ) : (
+          <path d="M35,75 L35,25" />
         )}
-        {/* 外側線 */}
-        <g fill="none" stroke="hsl(0, 0%, 0%)" strokeWidth="4">
-          {data.merge === "right" ? (
-            <path d="M35,75 L35,55 L48,45 L48,25" />
-          ) : (
-            <path d="M35,75 L35,25" />
-          )}
-          {data.merge === "left" ? (
-            <path d="M65,75 L65,55 L52,45 L52,25" />
-          ) : (
-            <path d="M65,75 L65,25" />
-          )}
-        </g>
-        {/* 内側線 */}
-        <g fill="none" stroke="hsl(58, 50%, 40%)" strokeWidth="3">
+        {data.merge === "left" ? (
+          <path d="M65,75 L65,55 L52,45 L52,25" />
+        ) : (
+          <path d="M65,75 L65,25" />
+        )}
+      </g>
+      {/* 内側線 */}
+      <g fill="none" stroke="hsl(58, 50%, 40%)" strokeWidth="3">
+        <path d="M50,75 L50,64" />
+        <path d="M50,61 L50,50" />
+      </g>
+      {/* 複数車線 */}
+      {data.multi === true && (
+        <g
+          fill="none"
+          stroke="hsl(58, 50%, 40%)"
+          strokeWidth="3"
+          transform={`translate(${data.merge === "left" ? -7 : 7})`}
+        >
           <path d="M50,75 L50,64" />
           <path d="M50,61 L50,50" />
+          <path d="M50,47 L50,36" />
+          <path d="M50,33 L50,25" />
         </g>
-        {/* 複数車線 */}
-        {data.multi === true && (
-          <g
-            fill="none"
-            stroke="hsl(58, 50%, 40%)"
-            strokeWidth="3"
-            transform={`translate(${data.merge === "left" ? -7 : 7})`}
-          >
-            <path d="M50,75 L50,64" />
-            <path d="M50,61 L50,50" />
-            <path d="M50,47 L50,36" />
-            <path d="M50,33 L50,25" />
-          </g>
-        )}
-        {/* 矢印 */}
-        {/* <path
+      )}
+      {/* 矢印 */}
+      {/* <path
           d="M50,0 L55,10 L52,10 L52,20 L48,20 L48,10 L45,10 z"
           fill="hsl(58, 50%, 50%)"
           stroke="none"
           transform={`translate(${data.merge === "right" ? 6 : -6} 30)`}
         /> */}
-      </g>
     </svg>
   );
 }


### PR DESCRIPTION
スタイルを変更する。

### 文字色

9344d592d7dcfbef74e437889ad9d55dcbe8a84f

一部環境（ひとまず iOS Safari）で文字色が白くなっていたため、全体の文字色を明確に黒に設定する。

この原因は恐らくダークモードになっていることによって文字色が勝手に設定されたためではないかと推測。

### スクロールバー表示

e8768fe4e165501439bba0bda079e377df571191

先の PR で、情報表示ビューが縦方向にはみ出した場合はスクロールするようにしたが、そのため右端に常にスクロールバーが表示されるようになって邪魔だったため、表示しないようにスタイルを設定する。

変更前 | 変更後
:--: | :--:
<img width="421" alt="image" src="https://github.com/user-attachments/assets/2bc5544b-6268-48f0-9bae-414fbabc178e" /> | <img width="417" alt="image" src="https://github.com/user-attachments/assets/4c673805-815b-4db7-8b57-48d18a00d530" />

当該機能は Newly Available だが、現時点ではユーザーが限られるため問題ないと判断。

また [MDN に記載の通り](https://developer.mozilla.org/ja/docs/Web/CSS/scrollbar-width#%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B7%E3%83%93%E3%83%AA%E3%83%86%E3%82%A3)、スクロールバーを使用してのスクロールが行えなくなるので、ユーザーの環境によっては問題が生じる恐れがあるが、こちらも現時点ではユーザーが限られるため問題ないと判断。

### 合流画像回転方法

75e0ea5e07734b2eda8f53fc742c30f3cb99c4fd

これまで合流画像は、SVG の中身を `g` で囲って回転させていた。この場合、回転中心を SVG の中心に合わせてやる必要があった。

今回、分岐画像と合わせる形で、SVG 自体を回転させるように変更する。これにより、画像中心により回転するため、記述がシンプルになる。

恐らく将来的に表示を追加する場合（ユーザー選択されている地点の画像に表示を追加する際など）にこちらの方が楽になるはず。
