### PR TITLE
feat: 情報表示ビューに車線減少の画像を表示

### DIFF
--- a/src/components/BranchPin.tsx
+++ b/src/components/BranchPin.tsx
@@ -43,27 +43,40 @@ export function BranchPin({ data, size = 40 }: Props) {
 }
 
 /**
+ * サイズの縮小や背景の描画を行っていない、素の状態の車線の SVG 画像を返す
+ */
+export function BareBranchLanesSvg({ data, size = 40 }: { data: BranchPoint; size?: number }) {
+  const svgWidth = LANE_WIDTH * data.lanes.length + 28;
+  return (
+    <svg height={size} viewBox={`0 0 ${svgWidth} 100`}>
+      <title>{data.label}</title>
+      <g transform={"translate(14, 50)"}>{lanesPath(data.lanes)}</g>
+    </svg>
+  );
+}
+
+/**
  * 車線部分のパスを生成する
  */
 function lanesPath(lanes: BranchPoint["lanes"]) {
   return (
     <>
-        <path d="M0,-25 l0,50" stroke="hsl(0, 0%, 100%)" strokeWidth={4} /> {/* 左端の線 */}
+      <path d="M0,-25 l0,50" stroke="hsl(0, 0%, 100%)" strokeWidth={4} /> {/* 左端の線 */}
       {lanes.map((lane, index) => (
-          <g
-            // biome-ignore lint/suspicious/noArrayIndexKey: 静的データを元にしていてインデックスが変化することはないため問題ない
-            key={`${lane}-${index}`}
-            transform={`translate(${LANE_WIDTH / 2 + index * LANE_WIDTH})`}
-          >
-            {arrowPath(lane)}
-            {/* 車線間の線。最後は右端なので太くする */}
-            <path
-              d={`M${LANE_WIDTH / 2},-25 l0,50`}
-              stroke="hsl(0, 0%, 100%)"
+        <g
+          // biome-ignore lint/suspicious/noArrayIndexKey: 静的データを元にしていてインデックスが変化することはないため問題ない
+          key={`${lane}-${index}`}
+          transform={`translate(${LANE_WIDTH / 2 + index * LANE_WIDTH})`}
+        >
+          {arrowPath(lane)}
+          {/* 車線間の線。最後は右端なので太くする */}
+          <path
+            d={`M${LANE_WIDTH / 2},-25 l0,50`}
+            stroke="hsl(0, 0%, 100%)"
             strokeWidth={index === lanes.length - 1 ? 4 : 2}
-            />
-          </g>
-        ))}
+          />
+        </g>
+      ))}
     </>
   );
 }

--- a/src/components/BranchPin.tsx
+++ b/src/components/BranchPin.tsx
@@ -44,6 +44,15 @@ export function BranchPin({ data, size = 40 }: Props) {
 
 /**
  * サイズの縮小や背景の描画を行っていない、素の状態の車線の SVG 画像を返す
+ *
+ * ピンを生成する `BranchPin` とは以下のような挙動の大きな違いがあり、
+ * 同一の関数とすると条件分岐が複雑になることから、別の関数として定義している。
+ *
+ * 対象 | ピン | この関数
+ * :--: | :--: | :--:
+ * 横幅 | 固定 | 可変
+ * 内容のサイズ | 縮小 | 固定
+ * 車線の配置 | 左右中央・少し下 | 上下左右中央
  */
 export function BareBranchLanesSvg({ data, size = 40 }: { data: BranchPoint; size?: number }) {
   const svgWidth = LANE_WIDTH * data.lanes.length + 28;

--- a/src/components/BranchPin.tsx
+++ b/src/components/BranchPin.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from "react";
 import type { BranchPoint } from "../types/types";
 
 type Props = {
@@ -12,10 +11,6 @@ type Props = {
   size?: number;
 };
 
-const SVG_STYLE: CSSProperties = {
-  cursor: "pointer",
-};
-
 // TODO: 道路の種類に応じて色を変える
 
 const LANE_WIDTH = 40;
@@ -26,7 +21,7 @@ const X_SCALE = 0.9;
  */
 export function BranchPin({ data, size = 40 }: Props) {
   return (
-    <svg height={size} viewBox="0 0 100 100" style={SVG_STYLE} transform={`rotate(${data.angle})`}>
+    <svg height={size} viewBox="0 0 100 100" transform={`rotate(${data.angle})`}>
       <title>{data.label}</title>
       {/* 背景 */}
       <path

--- a/src/components/BranchPin.tsx
+++ b/src/components/BranchPin.tsx
@@ -41,8 +41,20 @@ export function BranchPin({ data, size = 40 }: Props) {
       <g
         transform={`translate(14, 60) scale(${2 < data.lanes.length ? (2 * X_SCALE) / data.lanes.length : X_SCALE}, 1)`}
       >
+        {lanesPath(data.lanes)}
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * 車線部分のパスを生成する
+ */
+function lanesPath(lanes: BranchPoint["lanes"]) {
+  return (
+    <>
         <path d="M0,-25 l0,50" stroke="hsl(0, 0%, 100%)" strokeWidth={4} /> {/* 左端の線 */}
-        {data.lanes.map((lane, index) => (
+      {lanes.map((lane, index) => (
           <g
             // biome-ignore lint/suspicious/noArrayIndexKey: 静的データを元にしていてインデックスが変化することはないため問題ない
             key={`${lane}-${index}`}
@@ -53,12 +65,11 @@ export function BranchPin({ data, size = 40 }: Props) {
             <path
               d={`M${LANE_WIDTH / 2},-25 l0,50`}
               stroke="hsl(0, 0%, 100%)"
-              strokeWidth={index === data.lanes.length - 1 ? 4 : 2}
+            strokeWidth={index === lanes.length - 1 ? 4 : 2}
             />
           </g>
         ))}
-      </g>
-    </svg>
+    </>
   );
 }
 

--- a/src/components/InformationView.tsx
+++ b/src/components/InformationView.tsx
@@ -65,14 +65,14 @@ function BranchImage({ data }: { data: BranchPoint }) {
     display: "inline-flex",
     alignItems: "center",
     borderRadius: "4px",
-    height: "30px",
+    height: "44px",
     overflow: "hidden",
     marginTop: "8px",
   };
 
   return (
     <div style={BRANCH_WRAPPER_STYLE}>
-      <BareBranchLanesSvg data={data} />
+      <BareBranchLanesSvg data={data} size={60} />
     </div>
   );
 }

--- a/src/components/InformationView.tsx
+++ b/src/components/InformationView.tsx
@@ -36,8 +36,6 @@ function DataInner({ data }: { data: PointDataType }) {
  * 角度を `0` にして上向きにして前景だけを描画した SVG を取得し、独自の背景の上に重ねたもの。
  */
 function MergeImage({ data }: { data: MergePoint }) {
-  const icon = <MergePin data={{ ...data, angle: 0 }} onlyFront />;
-
   const MERGE_WRAPPER_STYLE: CSSProperties = {
     background: "hsl(58, 100%, 70%)",
     display: "flex",
@@ -49,7 +47,11 @@ function MergeImage({ data }: { data: MergePoint }) {
     marginTop: "8px",
   };
 
-  return <div style={MERGE_WRAPPER_STYLE}>{icon}</div>;
+  return (
+    <div style={MERGE_WRAPPER_STYLE}>
+      <MergePin data={{ ...data, angle: 0 }} onlyFront />
+    </div>
+  );
 }
 
 /**

--- a/src/components/InformationView.tsx
+++ b/src/components/InformationView.tsx
@@ -1,7 +1,8 @@
 import { useAtomValue } from "jotai";
 import type { CSSProperties } from "react";
 import { selectedPointDataAtom } from "../atoms/app";
-import type { MergePoint, PointDataType } from "../types/types";
+import type { BranchPoint, MergePoint, PointDataType } from "../types/types";
+import { BareBranchLanesSvg } from "./BranchPin";
 import { MergePin } from "./MergePin";
 
 /**
@@ -21,7 +22,7 @@ function DataInner({ data }: { data: PointDataType }) {
   return (
     <>
       <h2>{data.label}</h2>
-      {data.type === "merge" ? <MergeImage data={data} /> : null}
+      {data.type === "merge" ? <MergeImage data={data} /> : <BranchImage data={data} />}
       {data.comments?.map((line) => (
         <p key={line}>{line}</p>
       ))}
@@ -49,4 +50,27 @@ function MergeImage({ data }: { data: MergePoint }) {
   };
 
   return <div style={MERGE_WRAPPER_STYLE}>{icon}</div>;
+}
+
+/**
+ * 分岐画像を返す
+ *
+ * 上向きでサイズを縮小せず、独自の背景の上に重ねたもの。
+ */
+function BranchImage({ data }: { data: BranchPoint }) {
+  const BRANCH_WRAPPER_STYLE: CSSProperties = {
+    background: "hsl(230, 100%, 60%)",
+    display: "inline-flex",
+    alignItems: "center",
+    borderRadius: "4px",
+    height: "30px",
+    overflow: "hidden",
+    marginTop: "8px",
+  };
+
+  return (
+    <div style={BRANCH_WRAPPER_STYLE}>
+      <BareBranchLanesSvg data={data} />
+    </div>
+  );
 }

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -44,6 +44,7 @@ export function MapView() {
           latitude={data.latitude}
           anchor="center"
           onClick={() => setSelectedData({ type: "branch", ...data })}
+          style={{ cursor: "pointer" }}
         >
           <BranchPin data={data} />
         </Marker>


### PR DESCRIPTION
情報表示ビューに車線減少の画像を表示する機能を追加する。

<img width="427" alt="image" src="https://github.com/user-attachments/assets/d42feb73-ac16-46f8-87e0-614265d4a4e4" />

同時に、車線画像生成コンポーネントのリファクタリング等を行う。
