### PR TITLE
fix: Marker の class 指定で余計なスペースにより表示不能となる事象を修正

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -28,7 +28,11 @@ export function MapView() {
           latitude={data.latitude}
           anchor="center"
           onClick={() => setSelectedData({ type: "merge", ...data })}
-          className={`point-marker ${selectedData && isEqualPointData(selectedData, data) ? "selected" : ""}`}
+          className={
+            selectedData && isEqualPointData(selectedData, data)
+              ? "point-marker selected"
+              : "point-marker"
+          }
         >
           <MergePin data={data} />
         </Marker>
@@ -45,7 +49,11 @@ export function MapView() {
           latitude={data.latitude}
           anchor="center"
           onClick={() => setSelectedData({ type: "branch", ...data })}
-          className={`point-marker ${selectedData && isEqualPointData(selectedData, data) ? "selected" : ""}`}
+          className={
+            selectedData && isEqualPointData(selectedData, data)
+              ? "point-marker selected"
+              : "point-marker"
+          }
         >
           <BranchPin data={data} />
         </Marker>


### PR DESCRIPTION
MapLibre の Marker に対して `className` を指定する際、余計なスペースが入ることにより地図が表示不能となっていたため、修正する。

## 詳細

地図表示不能な際にブラウザのコンソールには `Uncaught DOMException: DOMTokenList.add: The empty string is not a valid token.` と表示されている。

<img width="569" alt="image" src="https://github.com/user-attachments/assets/20a46d96-9cad-4db7-aa47-458f092128c3" />

検証したところ、マーカーの**生成時**においては `className` の指定に応じて以下のような挙動となっていた。（この挙動は生成時のみであり、生成後に `className` を切り替える場合はこの限りではない）

`className` | 表示可否
-- | :--:
`a` | 🟢
`a ` | ❌
` a` | ❌
`a b` | 🟢
`a  b` | ❌

[コードを確認](https://github.com/maplibre/maplibre-gl-js/blob/b3e282bbb0b8f93b503895281ec313a4e2a1c6be/src/ui/marker.ts#L296-L300)したところ、初期化時に単純に `" "` で区切った結果をクラスの一覧に追加する挙動となっているため、区切り後に空文字列が含まれると不正な結果となる模様。

恐らく MapLibre GL JS 側に問題があるので将来的には PR を出すことも検討するが、ひとまず、クラス指定において余分なスペースを含まないように処理を変更して対応する。
