### PR TITLE
feat: コメントの中身が空文字列のときは出力しない

### DIFF
--- a/src/components/InformationView.tsx
+++ b/src/components/InformationView.tsx
@@ -23,9 +23,7 @@ function DataInner({ data }: { data: PointDataType }) {
     <>
       <h2>{data.label}</h2>
       {data.type === "merge" ? <MergeImage data={data} /> : <BranchImage data={data} />}
-      {data.comments?.map((line) => (
-        <p key={line}>{line}</p>
-      ))}
+      {data.comments?.map((line) => line !== "" && <p key={line}>{line}</p>)}
     </>
   );
 }


### PR DESCRIPTION
情報表示ビューで、コメントの配列の中身が空文字列のときに、何も出力しないようにする。

これまでは空文字列でも `p` タグを出力していたため、余分なスペースが生じていたが、それを解消する。

変更前 | 変更後
:--: | :--:
<img width="429" alt="image" src="https://github.com/user-attachments/assets/bb5c69ea-0147-454a-816a-ce9418f82801" /> | <img width="428" alt="image" src="https://github.com/user-attachments/assets/bbfdb61d-342d-4ba3-828e-07b23af39351" />


