### PR TITLE
fix: Safari でも合流・分岐の SVG 画像が回転するように修正

### DIFF
--- a/src/components/BranchPin.tsx
+++ b/src/components/BranchPin.tsx
@@ -21,7 +21,7 @@ const X_SCALE = 0.9;
  */
 export function BranchPin({ data, size = 40 }: Props) {
   return (
-    <svg height={size} viewBox="0 0 100 100" transform={`rotate(${data.angle})`}>
+    <svg height={size} viewBox="0 0 100 100">
       <title>{data.label}</title>
       {/* 背景 */}
       <path

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -35,6 +35,7 @@ export function MapView() {
               ? "point-marker selected"
               : "point-marker"
           }
+          rotation={data.angle}
         >
           <MergePin data={data} />
         </Marker>
@@ -56,6 +57,7 @@ export function MapView() {
               ? "point-marker selected"
               : "point-marker"
           }
+          rotation={data.angle}
         >
           <BranchPin data={data} />
         </Marker>

--- a/src/components/MergePin.tsx
+++ b/src/components/MergePin.tsx
@@ -22,7 +22,7 @@ type Props = {
  */
 export function MergePin({ data, size = 40, onlyFront }: Props) {
   return (
-    <svg height={size} viewBox="0 0 100 100" transform={`rotate(${data.angle})`}>
+    <svg height={size} viewBox="0 0 100 100">
       <title>{data.label}</title>
       {/* 背景 */}
       {!onlyFront && (


### PR DESCRIPTION
これまでの作りでは Safari (iOS のブラウザも含む) では SVG の合流・分岐画像が回転していなかったため、きちんと回転するように修正する。

これまでは合流・分岐画像 `svg` 要素に `transform` として回転を指定していた。しかしこれでは Safari において回転しないことが判明したため、React Map GL の `Marker` 自体に回転を指定して改善する。

改善前 | 改善後
:--: | :--:
<img width="196" height="313" alt="image" src="https://github.com/user-attachments/assets/5443ca53-f8f2-427d-abdf-14dc52263f7c" /> | <img width="215" height="330" alt="image" src="https://github.com/user-attachments/assets/b2dbd649-f3bf-4509-aca9-7735a1c831b2" />


## 備考

[MDN](https://developer.mozilla.org/ja/docs/Web/SVG/Reference/Attribute/transform) によると、SVG 1.1 では `svg` 要素に対して `transform` を指定できないようだった。

[CanIUse](https://caniuse.com/mdn-svg_global_attributes_transform_svg_root) によると確かに Safari は現状でも対応していない。Firefox も対応していないことになっているが、手元ではきちんと動いているのは謎。
